### PR TITLE
Fix QPainter issue with Qt4

### DIFF
--- a/src/command.h
+++ b/src/command.h
@@ -31,6 +31,7 @@ class View2D;
 class PinEditDoc;
 class Group;
 class Shape3D;
+class QPainter;
 
 /** @author Henrik Enqvist */
 class CommandContext {
@@ -84,7 +85,7 @@ class Command {
 	virtual void execute(const CommandContext & context) = 0;
 	/** Some commands wishes to  generate a preview of the action onto a View2D. E.g.
 	 * movement of objects. */
-	virtual void preview(const CommandContext & context, View2D * view2d) = 0;
+    virtual void preview(const CommandContext & context, View2D * view2d, QPainter& painter) = 0;
 	/** Returns the name of the command subclass. Subclasses should implement
 	 * this function by returning a name that exaclty matches the name of 
 	 * the class. */

--- a/src/commandaddselect.cpp
+++ b/src/commandaddselect.cpp
@@ -71,11 +71,10 @@ void CommandAddSelect::execute(const CommandContext & context) {
     " to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandAddSelect::preview(const CommandContext & context, View2D * view2d) {
+void CommandAddSelect::preview(const CommandContext & context, View2D * /*view2d*/, QPainter &painter) {
   EM_CERR("CommandAddSelect::preview");
-  view2d->getPainter()->setPen(Qt::blue);
-  view2d->getPainter()->drawRect(context.sx1, context.sy1, 
-				 context.sx2 - context.sx1, context.sy2 - context.sy1);
+  painter.setPen(Qt::blue);
+  painter.drawRect(context.sx1, context.sy1, context.sx2 - context.sx1, context.sy2 - context.sy1);
 }
 
 void CommandAddSelect::undo() {

--- a/src/commandaddselect.h
+++ b/src/commandaddselect.h
@@ -28,9 +28,9 @@ class CommandAddSelect : public Command  {
 	Command * build();
 	void undo();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
 	void clearObjects();
-	const char * type() { return "CommandAddSelect"; };
+    const char * type() { return "CommandAddSelect"; }
 };
 
 #endif

--- a/src/commandcopy.h
+++ b/src/commandcopy.h
@@ -35,8 +35,8 @@ class CommandCopy : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	virtual const char * type() { return "CommandCopy"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    virtual const char * type() { return "CommandCopy"; }
 };
 
 #endif

--- a/src/commanddeletegroup.h
+++ b/src/commanddeletegroup.h
@@ -31,8 +31,8 @@ class CommandDeleteGroup : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext &, View2D *) {};
-	const char * type() { return "CommandDeleteGroup"; };
+    void preview(const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandDeleteGroup"; }
 };
 
 #endif

--- a/src/commanddeletepolygon.h
+++ b/src/commanddeletepolygon.h
@@ -35,8 +35,8 @@ class CommandDeletePolygon : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext &, View2D *) {};
-	const char * type() { return "CommandDeletePolygon"; };
+    void preview(const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandDeletePolygon"; }
  private:
 	vector<Polygon3D*> m_vPolygon;
 };

--- a/src/commanddeleteshape.h
+++ b/src/commanddeleteshape.h
@@ -31,8 +31,8 @@ class CommandDeleteShape : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext &, View2D *) {};
-	const char * type() { return "CommandDeleteShape"; };
+    void preview(const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandDeleteShape"; }
 };
 
 #endif

--- a/src/commanddeletevertex.h
+++ b/src/commanddeletevertex.h
@@ -35,8 +35,8 @@ class CommandDeleteVertex : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext &, View2D *) {};
-	const char * type() { return "CommandDeleteVertex"; };
+    void preview(const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandDeleteVertex"; }
  private:
 	vector<Vertex3D> m_vVertex;
 	vector<Color> m_vColor;

--- a/src/commandextrude.h
+++ b/src/commandextrude.h
@@ -35,8 +35,8 @@ class CommandExtrude : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	virtual const char * type() { return "CommandExtrude"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    virtual const char * type() { return "CommandExtrude"; }
  private:
 	vector<int> m_vNewVertex;
 	vector<Polygon3D*> m_vPolygon;

--- a/src/commandflip.h
+++ b/src/commandflip.h
@@ -35,8 +35,8 @@ class CommandFlip : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	const char * type() { return "CommandFlip"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandFlip"; }
  private:
 	vector<Polygon3D*> m_vPolygon;
 };

--- a/src/commandflipsmart.h
+++ b/src/commandflipsmart.h
@@ -35,8 +35,8 @@ class CommandFlipSmart : public Command  {
   void undo();
   void clearObjects();
   void execute(const CommandContext & context);
-  void preview (const CommandContext &, View2D *) {};
-  const char * type() { return "CommandFlipSmart"; };
+  void preview (const CommandContext &, View2D *, QPainter&) {}
+  const char * type() { return "CommandFlipSmart"; }
  private:
   vector<Polygon3D*> m_vPolygon;
 };

--- a/src/commandhideselected.cpp
+++ b/src/commandhideselected.cpp
@@ -49,7 +49,7 @@ void CommandHideSelected::execute(const CommandContext & context) {
 	// but selection is made correct !!!
 }
 
-void CommandHideSelected::preview(const CommandContext &, View2D *) {
+void CommandHideSelected::preview(const CommandContext &, View2D *, QPainter &) {
   EM_CERR("CommandHideSelected::preview");
 }
 

--- a/src/commandhideselected.h
+++ b/src/commandhideselected.h
@@ -29,8 +29,8 @@ class CommandHideSelected : public Command  {
 	void undo();
 	void clearObjects() {};
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	const char * type() { return "CommandHideSelected"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    const char * type() { return "CommandHideSelected"; }
 };
 
 #endif

--- a/src/commandmirror.h
+++ b/src/commandmirror.h
@@ -35,10 +35,10 @@ class CommandMirror : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
+    void preview (const CommandContext &, View2D *, QPainter&) {}
 	/** 0 = x, 1 = y, 2 = z; */
-	void setXYZ(int xyz) { m_iXYZ = xyz; };
-	const char * type() { return "CommandMirror"; };
+    void setXYZ(int xyz) { m_iXYZ = xyz; }
+    const char * type() { return "CommandMirror"; }
  private:
 	int m_iXYZ;
 	vector<int> m_vIndex;

--- a/src/commandmirrorlocal.h
+++ b/src/commandmirrorlocal.h
@@ -37,10 +37,10 @@ class CommandMirrorLocal : public Command  {
   void undo();
   void clearObjects();
   void execute(const CommandContext & context);
-  void preview (const CommandContext &, View2D *) {};
+  void preview (const CommandContext &, View2D *, QPainter&) {}
   /** 0 = x, 1 = y, 2 = z; */
-  void setXYZ(int xyz) { m_iXYZ = xyz; };
-  const char * type() { return "CommandMirrorLocal"; };
+  void setXYZ(int xyz) { m_iXYZ = xyz; }
+  const char * type() { return "CommandMirrorLocal"; }
  private:
   int m_iXYZ;
   Vertex3D m_vtxCenter;

--- a/src/commandmove.cpp
+++ b/src/commandmove.cpp
@@ -62,9 +62,9 @@ void CommandMove::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandMove::preview(const CommandContext & context, View2D * view2d) {
+void CommandMove::preview(const CommandContext & context, View2D * view2d, QPainter& painter) {
 	if (context.shape == NULL) return;
-	p_Context->copy(context);
+    p_Context->copy(context);
 	// build matrix stack for temporary translation
 	// mtxB is global rotion matrix, mtxC fixes the translation in local rotation
 	// mtxC is the final matrix
@@ -76,11 +76,11 @@ void CommandMove::preview(const CommandContext & context, View2D * view2d) {
 	EMath::getTransformationMatrix(mtxA, vtxTA, vtxRA, vtxSA);
 
 	// draw selected polygons
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	int index = 0;
 	Polygon3D * poly = p_Doc->getSelectedPolygon(index);
 	while (poly != NULL) {
-		view2d->drawPolygon(context.shape, poly, mtxA);
+        view2d->drawPolygon(painter, context.shape, poly, mtxA);
 		index++;
 		poly = p_Doc->getSelectedPolygon(index);
 	}
@@ -89,11 +89,11 @@ void CommandMove::preview(const CommandContext & context, View2D * view2d) {
 	Vertex3D * vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
 	while (vtx != NULL) {
 		// the matrix will rotate and reapply the translation
-		view2d->drawVertex(context.shape, *vtx, mtxA);
+        view2d->drawVertex(painter, context.shape, *vtx, mtxA);
 		index++;
 		vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
 	}
-	EM_CERR("commandmove::preview");
+    EM_CERR("commandmove::preview");
 }
 
 void CommandMove::undo() {

--- a/src/commandmove.h
+++ b/src/commandmove.h
@@ -35,7 +35,7 @@ class CommandMove : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
+    void preview(const CommandContext & context, View2D * view2d, QPainter &painter);
 	virtual const char * type() { return "CommandMove"; };
  private:
 	vector<Vertex3D> m_vVertex;

--- a/src/commandmovegroup.cpp
+++ b/src/commandmovegroup.cpp
@@ -54,9 +54,9 @@ void CommandMoveGroup::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandMoveGroup::preview(const CommandContext & context, View2D * view2d) {
+void CommandMoveGroup::preview(const CommandContext & context, View2D * view2d, QPainter &painter) {
 	EM_CERR("CommandMoveGroup::preview");
-	if (context.group == NULL) return;
+    if (context.group == NULL) return;
 	context.group->getTranslation(m_vtxTrans.x, m_vtxTrans.y, m_vtxTrans.z);
 
 	Matrix mtxA = EMath::identityMatrix;
@@ -84,20 +84,20 @@ void CommandMoveGroup::preview(const CommandContext & context, View2D * view2d) 
 	g = context.group;
 
 	// draw all polygons
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	int shindex = 0;
 	Shape3D * shape = g->getShape3D(shindex);
 	while (shape != NULL) {
 		int polyindex = 0;
 		Polygon3D * poly = shape->getPolygon(polyindex);
 		while (poly != NULL) {
-			view2d->drawPolygon(shape, poly, mtxC);
+            view2d->drawPolygon(painter, shape, poly, mtxC);
 			polyindex++;
 			poly = shape->getPolygon(polyindex);
 		}
 		shindex++;
 		shape = g->getShape3D(shindex);
-	}
+    }
 }
 
 void CommandMoveGroup::undo() {

--- a/src/commandmovegroup.h
+++ b/src/commandmovegroup.h
@@ -29,8 +29,8 @@ class CommandMoveGroup : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	const char * type() { return "CommandMoveGroup"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    const char * type() { return "CommandMoveGroup"; }
  private:
 	Vertex3D m_vtxTrans;
 };

--- a/src/commandnewbehavior.h
+++ b/src/commandnewbehavior.h
@@ -30,13 +30,13 @@ class CommandNewBehavior : public Command  {
   ~CommandNewBehavior();
   Command * build();
   void clearObjects();
-  inline void setBehaviorType(int t) { m_iBehaviorType = t; };
+  inline void setBehaviorType(int t) { m_iBehaviorType = t; }
   /** Gets the behavior, the command must be executed before a behavior will exist. */
-  inline Behavior * getBehavior() { return p_Behavior; };
+  inline Behavior * getBehavior() { return p_Behavior; }
   void undo();
   void execute(const CommandContext & context);
-  void preview (const CommandContext &, View2D *) {};
-  const char * type() { return "CommandNewBehavior"; };
+  void preview (const CommandContext &, View2D *, QPainter&) {}
+  const char * type() { return "CommandNewBehavior"; }
  private:
   Group * p_Group;
   Behavior * p_Behavior;

--- a/src/commandnewgroup.h
+++ b/src/commandnewgroup.h
@@ -31,8 +31,8 @@ class CommandNewGroup : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	const char * type() { return "CommandNewGroup"; };
-	void preview (const CommandContext &, View2D *) {};
+    const char * type() { return "CommandNewGroup"; }
+    void preview (const CommandContext &, View2D *, QPainter&) {}
  private:
 	Group * p_Group;
 };

--- a/src/commandnewpolygon.h
+++ b/src/commandnewpolygon.h
@@ -31,8 +31,8 @@ class CommandNewPolygon : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	const char * type() { return "CommandNewPolygon"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandNewPolygon"; }
  private:
 	Polygon3D * p_Polygon;
 };

--- a/src/commandnewshape.h
+++ b/src/commandnewshape.h
@@ -37,11 +37,11 @@ class CommandNewShape : public Command  {
 	~CommandNewShape();
 	Command * build();
 	void undo();
-	void setType(int type) { m_iType = type; };
+    void setType(int type) { m_iType = type; }
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	const char * type() { return "CommandNewShape"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandNewShape"; }
  private:
 	int m_iType;
 };

--- a/src/commandnewvertex.h
+++ b/src/commandnewvertex.h
@@ -29,8 +29,8 @@ class CommandNewVertex : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	const char * type() { return "CommandNewVertex"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandNewVertex"; }
  private:
 	int m_iVtxIndex;
 };

--- a/src/commandpaste.h
+++ b/src/commandpaste.h
@@ -35,8 +35,8 @@ class CommandPaste : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	virtual const char * type() { return "CommandPaste"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    virtual const char * type() { return "CommandPaste"; }
  private:
 	int m_iUndoIndex;
 	//vector<int> m_vNewVertex;

--- a/src/commandresize.cpp
+++ b/src/commandresize.cpp
@@ -59,13 +59,13 @@ void CommandResize::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandResize::preview(const CommandContext & context, View2D * view2d) {
+void CommandResize::preview(const CommandContext & context, View2D * view2d, QPainter & painter) {
 	assert(view2d != NULL);
-	if (context.shape == NULL) return;
+    if (context.shape == NULL) return;
 	float dx = context.x2 - context.x1;
 	float dy = context.y2 - context.y1;
 	float dz = context.z2 - context.z1;
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	int index = 0;
 	Vertex3D * vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
 	Vertex3D vtxA;
@@ -76,19 +76,19 @@ void CommandResize::preview(const CommandContext & context, View2D * view2d) {
 		vtxA.z = vtx->z * (float)(PE_RESIZE_FACTOR + dz)/PE_RESIZE_FACTOR;
 		//EM_CERR(vtx->x <<" "<< vtx->y <<" "<< vtx->z);
 		switch (context.type) {
-		case XY: view2d->getPainter()->drawRect(view2d->screenx(vtxA.x)-1, 
+        case XY: painter.drawRect(view2d->screenx(vtxA.x)-1,
 							view2d->screeny(-vtxA.y)-1, 
 							3, 3); break;
-		case XZ: view2d->getPainter()->drawRect(view2d->screenx(vtxA.x)-1, 
+        case XZ: painter.drawRect(view2d->screenx(vtxA.x)-1,
 							view2d->screeny(vtxA.z)-1, 
 							3, 3); break;
-		case ZY: view2d->getPainter()->drawRect(view2d->screenx(vtxA.z)-1, 
+        case ZY: painter.drawRect(view2d->screenx(vtxA.z)-1,
 							view2d->screeny(-vtxA.y)-1, 
 							3, 3); break;
 		}
 		index++;
 		vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
-	}
+    }
 	EM_CERR("commandmove::preview");
 }
 

--- a/src/commandresize.h
+++ b/src/commandresize.h
@@ -33,10 +33,10 @@ class CommandResize : public Command  {
 	~CommandResize();
 	Command * build();
 	void undo();
-	void clearObjects() {};
+    void clearObjects() {}
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	virtual const char * type() { return "CommandResize"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter&painter);
+    virtual const char * type() { return "CommandResize"; }
  private:
 	vector<Vertex3D> m_vVertex;
 	vector<int> m_vIndex;

--- a/src/commandresizelocal.cpp
+++ b/src/commandresizelocal.cpp
@@ -65,14 +65,14 @@ void CommandResizeLocal::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandResizeLocal::preview(const CommandContext & context, View2D * view2d) {
+void CommandResizeLocal::preview(const CommandContext & context, View2D * view2d, QPainter &painter) {
 	assert(view2d != NULL);
-	EM_CERR("CommandResizeLocal::preview");
+    EM_CERR("CommandResizeLocal::preview");
 	if (context.shape == NULL) return;
 	float dx = context.x2 - context.x1;
 	float dy = context.y2 - context.y1;
 	float dz = context.z2 - context.z1;
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	Vertex3D origo;
 	p_Doc->getSelectedCenter(origo);
 	int index = 0;
@@ -87,19 +87,19 @@ void CommandResizeLocal::preview(const CommandContext & context, View2D * view2d
 		vtxA.z = vz * (float)(PE_RESIZE_FACTOR + dz)/PE_RESIZE_FACTOR + origo.z;
 		//EM_CERR(vtx->x <<" "<< vtx->y <<" "<< vtx->z);
 		switch (context.type) {
-		case XY: view2d->getPainter()->drawRect(view2d->screenx(vtxA.x)-1, 
+        case XY: painter.drawRect(view2d->screenx(vtxA.x)-1,
 							view2d->screeny(-vtxA.y)-1, 
 							3, 3); break;
-		case XZ: view2d->getPainter()->drawRect(view2d->screenx(vtxA.x)-1, 
+        case XZ: painter.drawRect(view2d->screenx(vtxA.x)-1,
 							view2d->screeny(vtxA.z)-1, 
 							3, 3); break;
-		case ZY: view2d->getPainter()->drawRect(view2d->screenx(vtxA.z)-1, 
+        case ZY: painter.drawRect(view2d->screenx(vtxA.z)-1,
 							view2d->screeny(-vtxA.y)-1, 
 							3, 3); break;
 		}
 		index++;
 		vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
-	}
+    }
 }
 
 void CommandResizeLocal::undo() {

--- a/src/commandresizelocal.h
+++ b/src/commandresizelocal.h
@@ -33,10 +33,10 @@ class CommandResizeLocal : public Command  {
 	~CommandResizeLocal();
 	Command * build();
 	void undo();
-	void clearObjects() {};
+    void clearObjects() {}
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	virtual const char * type() { return "CommandResizeLocal"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    virtual const char * type() { return "CommandResizeLocal"; }
  private:
 	vector<Vertex3D> m_vVertex;
 	vector<int> m_vIndex;

--- a/src/commandrotate.cpp
+++ b/src/commandrotate.cpp
@@ -64,9 +64,9 @@ void CommandRotate::execute(const CommandContext & context) {
 	p_Doc->pushUndo(this);
 }
 
-void CommandRotate::preview(const CommandContext & context, View2D * view2d) {
+void CommandRotate::preview(const CommandContext & context, View2D * view2d, QPainter &painter) {
 	EM_CERR("CommandRotate::preview");
-	if (context.shape == NULL) return;
+    if (context.shape == NULL) return;
 	// build matrix stack for temporary translation
 	// mtxB is global rotion matrix, mtxC fixes the translation in local rotation
 	// mtxC is the final matrix
@@ -81,11 +81,11 @@ void CommandRotate::preview(const CommandContext & context, View2D * view2d) {
 	EMath::getTransformationMatrix(mtxA, vtxTA, vtxRA, vtxSA);
 
 	// draw selected polygons
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	int index = 0;
 	Polygon3D * poly = p_Doc->getSelectedPolygon(index);
 	while (poly != NULL) {
-		view2d->drawPolygon(context.shape, poly, mtxA);
+        view2d->drawPolygon(painter, context.shape, poly, mtxA);
 		index++;
 		poly = p_Doc->getSelectedPolygon(index);
 	}
@@ -94,10 +94,10 @@ void CommandRotate::preview(const CommandContext & context, View2D * view2d) {
 	Vertex3D * vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
 	while (vtx != NULL) {
 		// the matrix will rotate and reapply the translation
-		view2d->drawVertex(context.shape, *vtx, mtxA);
+        view2d->drawVertex(painter, context.shape, *vtx, mtxA);
 		index++;
 		vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
-	}
+    }
 }
 
 void CommandRotate::undo() {

--- a/src/commandrotate.h
+++ b/src/commandrotate.h
@@ -33,10 +33,10 @@ class CommandRotate : public Command  {
 	~CommandRotate();
 	Command * build();
 	void undo();
-	void clearObjects() {};
+    void clearObjects() {}
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	virtual const char * type() { return "CommandRotate"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    virtual const char * type() { return "CommandRotate"; }
  private:
 	vector<Vertex3D> m_vVertex;
 	vector<int> m_vIndex;

--- a/src/commandrotategroup.cpp
+++ b/src/commandrotategroup.cpp
@@ -58,9 +58,9 @@ void CommandRotateGroup::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandRotateGroup::preview(const CommandContext & context, View2D * view2d) {
+void CommandRotateGroup::preview(const CommandContext & context, View2D * view2d, QPainter &painter) {
 	EM_CERR("CommandRotateGroup::preview");
-	if (context.group == NULL) return;
+    if (context.group == NULL) return;
 
 	Matrix mtxA = EMath::identityMatrix;
 	Matrix mtxB = EMath::identityMatrix;
@@ -88,20 +88,20 @@ void CommandRotateGroup::preview(const CommandContext & context, View2D * view2d
 	}
 	g = context.group;
 	// draw all polygons
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	int shindex = 0;
 	Shape3D * shape = g->getShape3D(shindex);
 	while (shape != NULL) {
 		int polyindex = 0;
 		Polygon3D * poly = shape->getPolygon(polyindex);
 		while (poly != NULL) {
-			view2d->drawPolygon(shape, poly, mtxB);
+            view2d->drawPolygon(painter, shape, poly, mtxB);
 			polyindex++;
 			poly = shape->getPolygon(polyindex);
 		}
 		shindex++;
 		shape = g->getShape3D(shindex);
-	}
+    }
 	EM_CERR("CommandRotateGroup::preview");
 }
 

--- a/src/commandrotategroup.h
+++ b/src/commandrotategroup.h
@@ -31,8 +31,8 @@ class CommandRotateGroup : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	virtual const char * type() { return "CommandRotateGroup"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    virtual const char * type() { return "CommandRotateGroup"; }
  private:
 	Vertex3D m_vtxRot;
 };

--- a/src/commandrotatelocal.cpp
+++ b/src/commandrotatelocal.cpp
@@ -82,9 +82,9 @@ void CommandRotateLocal::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandRotateLocal::preview(const CommandContext & context, View2D * view2d) {
+void CommandRotateLocal::preview(const CommandContext & context, View2D * view2d, QPainter &painter) {
 	if (context.shape == NULL) return;
-	EM_CERR("CommandRotateLocal::preview");
+    EM_CERR("CommandRotateLocal::preview");
 	// build matrix stack for temporary translation
 	// mtxA is moves and rotates , mtxB fixes the translation to local rotation
 	// mtxC is the final matrix
@@ -110,11 +110,11 @@ void CommandRotateLocal::preview(const CommandContext & context, View2D * view2d
 	EMath::matrixMulti(mtxB, mtxA, mtxC);
 	
 	// draw selected polygons
-	view2d->getPainter()->setPen(Qt::green);
+    painter.setPen(Qt::green);
 	int index = 0;
 	Polygon3D * poly = p_Doc->getSelectedPolygon(index);
 	while (poly != NULL) {
-		view2d->drawPolygon(context.shape, poly, mtxC);
+        view2d->drawPolygon(painter, context.shape, poly, mtxC);
 		index++;
 		poly = p_Doc->getSelectedPolygon(index);
 	}
@@ -123,11 +123,11 @@ void CommandRotateLocal::preview(const CommandContext & context, View2D * view2d
 	Vertex3D * vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
 	while (vtx != NULL) {
 		// the matrix will rotate and reapply the translation
-		view2d->drawVertex(context.shape, *vtx, mtxC);
+        view2d->drawVertex(painter, context.shape, *vtx, mtxC);
 		index++;
 		vtx = context.shape->getVertex3D(p_Doc->getSelectedVertex(index));
 	}
-	//EM_CERR("drawed " << index << " temporary polygons");
+    //EM_CERR("drawed " << index << " temporary polygons");
 }
 
 void CommandRotateLocal::undo() {

--- a/src/commandrotatelocal.h
+++ b/src/commandrotatelocal.h
@@ -35,8 +35,8 @@ class CommandRotateLocal : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	virtual const char * type() { return "CommandRotateLocal"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    virtual const char * type() { return "CommandRotateLocal"; }
  private:
 	vector<Vertex3D> m_vVertex;
 	vector<int> m_vIndex;

--- a/src/commandselect.cpp
+++ b/src/commandselect.cpp
@@ -78,11 +78,10 @@ void CommandSelect::execute(const CommandContext & context) {
 		" to " << context.x2 <<"  "<< context.y2 <<" "<< context.z2);
 }
 
-void CommandSelect::preview(const CommandContext & context, View2D * view2d) {
+void CommandSelect::preview(const CommandContext & context, View2D * /*view2d*/, QPainter& painter) {
 	EM_CERR("CommandSelect::drawpreview");
-	view2d->getPainter()->setPen(Qt::blue);
-	view2d->getPainter()->drawRect(context.sx1, context.sy1, 
-										 context.sx2 - context.sx1, context.sy2 - context.sy1);
+    painter.setPen(Qt::blue);
+    painter.drawRect(context.sx1, context.sy1, context.sx2 - context.sx1, context.sy2 - context.sy1);
 }
 
 void CommandSelect::undo() {

--- a/src/commandselect.h
+++ b/src/commandselect.h
@@ -29,8 +29,8 @@ class CommandSelect : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	const char * type() { return "CommandSelect"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    const char * type() { return "CommandSelect"; }
 };
 
 #endif

--- a/src/commandsnap.h
+++ b/src/commandsnap.h
@@ -35,12 +35,12 @@ class CommandSnap : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void setFactor(float factor) { m_fFactor = factor; };
-	void preview(const CommandContext &, View2D *) {};
-	void setX(bool x) { m_bX = x; };
-	void setY(bool y) { m_bY = y; };
-	void setZ(bool z) { m_bZ = z; };
-	const char * type() { return "CommandSnap"; };
+    void setFactor(float factor) { m_fFactor = factor; }
+    void preview(const CommandContext &, View2D *, QPainter&) {}
+    void setX(bool x) { m_bX = x; }
+    void setY(bool y) { m_bY = y; }
+    void setZ(bool z) { m_bZ = z; }
+    const char * type() { return "CommandSnap"; }
  private:
 	vector<Vertex3D> m_vVertex;
 	vector<int> m_vIndex;

--- a/src/commandtexcoord.h
+++ b/src/commandtexcoord.h
@@ -27,10 +27,10 @@ class CommandTexCoord : public Command  {
 	~CommandTexCoord();
 	Command * build();
 	void undo();
-	void clearObjects() {};
+    void clearObjects() {}
 	void execute(const CommandContext & context);
-	void preview (const CommandContext &, View2D *) {};
-	const char * type() { return "CommandTexCoord"; };
+    void preview (const CommandContext &, View2D *, QPainter&) {}
+    const char * type() { return "CommandTexCoord"; }
 };
 
 #endif

--- a/src/commandunselect.cpp
+++ b/src/commandunselect.cpp
@@ -69,11 +69,10 @@ void CommandUnSelect::execute(const CommandContext & context) {
 		" to " << ct.x2 <<"  "<< ct.y2 <<" "<< ct.z2);
 }
 
-void CommandUnSelect::preview(const CommandContext & context, View2D * view2d) {
-	view2d->getPainter()->setPen(Qt::blue);
-	view2d->getPainter()->drawRect(context.sx1, context.sy1, 
-				       context.sx2 - context.sx1, context.sy2 - context.sy1);
-	EM_CERR("CommandUnSelect::preview");
+void CommandUnSelect::preview(const CommandContext & context, View2D * /*view2d*/, QPainter &painter) {
+    painter.setPen(Qt::blue);
+    painter.drawRect(context.sx1, context.sy1, context.sx2 - context.sx1, context.sy2 - context.sy1);
+    EM_CERR("CommandUnSelect::preview");
 }
 
 void CommandUnSelect::undo() {

--- a/src/commandunselect.h
+++ b/src/commandunselect.h
@@ -29,8 +29,8 @@ class CommandUnSelect : public Command  {
 	void undo();
 	void clearObjects();
 	void execute(const CommandContext & context);
-	void preview(const CommandContext & context, View2D * view2d);
-	const char * type() { return "CommandUnSelect"; };
+    void preview(const CommandContext & context, View2D * view2d, QPainter& painter);
+    const char * type() { return "CommandUnSelect"; }
 };
 
 #endif

--- a/src/pineditdoc.cpp
+++ b/src/pineditdoc.cpp
@@ -69,7 +69,8 @@ void PinEditDoc::newDoc() {
   this->setCurrentGroup(NULL);
   // TODO this will leak memory
   // Create the engine.
-  char * my_argv[] = {"exename", "-externgl", "-nosound", "-size", "300", "240"};
+  char arguments[][10] = {"exename", "-externgl", "-nosound", "-size", "300", "240"};
+  char * my_argv[] = {arguments[0], arguments[1], arguments[2], arguments[3], arguments[4], arguments[5]};
   int my_argc = 6;
   p_Engine = new Engine(my_argc, my_argv);
   p_Engine->setLightning(0.5f, 0.5f);

--- a/src/polygonview.cpp
+++ b/src/polygonview.cpp
@@ -258,7 +258,7 @@ void PolygonView::setPolygon(Shape3D * shape, Polygon3D * poly) {
       QString().setNum(texcoord->u, 'g', 2) + " " +
       QString().setNum(texcoord->v, 'g', 2);
     ListItem * vtxitem = new ListItem(p_VertexListView, str);
-    vtxitem->setObject(INT2OBJ(vtxindex), LISTITEM_VERTEX);
+    vtxitem->setObject(INT2OBJ((intptr_t)vtxindex), LISTITEM_VERTEX);
 	
     index++;
     vtxindex = poly->getIndex(index);

--- a/src/textureview.cpp
+++ b/src/textureview.cpp
@@ -54,7 +54,6 @@ TextureImageWidget::TextureImageWidget(PinEditDoc * doc, QWidget * parent,
   p_Image = NULL;
   p_Doc = doc;
   this->setFixedSize(256, 256);
-  p_Painter = new QPainter(this);
   this->setBackgroundMode(Qt::PaletteBase);
 }
 
@@ -115,14 +114,14 @@ void TextureImageWidget::setInit(QImage * image, TextureView * view) {
   }
 }
 
-void TextureImageWidget::drawPolygon(Polygon3D * poly) {
+void TextureImageWidget::drawPolygon(QPainter& painter, Polygon3D * poly) {
   assert(poly != NULL);
   // draw lines between texcoords
   int texindex = 1;
   TexCoord * texcoordbak = poly->getTexCoord(0);
   TexCoord * texcoord = poly->getTexCoord(texindex);
   while (texcoord != NULL) {
-    p_Painter->drawLine((int)(texcoordbak->u*255.0f), (int)(texcoordbak->v*255.0f),
+    painter.drawLine((int)(texcoordbak->u*255.0f), (int)(texcoordbak->v*255.0f),
 			(int)(texcoord->u*255.0f), (int)(texcoord->v*255.0f));
     texcoordbak = texcoord;
     ++texindex;
@@ -132,7 +131,7 @@ void TextureImageWidget::drawPolygon(Polygon3D * poly) {
   texcoord = poly->getTexCoord(0);
   assert(texcoordbak != NULL);
   assert(texcoord != NULL);
-  p_Painter->drawLine((int)(texcoordbak->u*255.0f), (int)(texcoordbak->v*255.0f), 
+  painter.drawLine((int)(texcoordbak->u*255.0f), (int)(texcoordbak->v*255.0f),
 		      (int)(texcoord->u*255.0f), (int)(texcoord->v*255.0f));
 }
 
@@ -142,27 +141,28 @@ void TextureImageWidget::paintEvent(QPaintEvent *) {
   if (shape == NULL) return;
   if (p_Image == NULL) return;
   if (p_texCurrent == NULL) return;
-  p_Painter->drawImage(0, 0, *p_Image);
+  QPainter painter(this);
+  painter.drawImage(0, 0, *p_Image);
   // draw all polygons in green
-  p_Painter->setPen(Qt::green);
+  painter.setPen(Qt::green);
   int polyindex = 0;
   Polygon3D * poly = shape->getPolygon(polyindex);
   while (poly != NULL) {
-    this->drawPolygon(poly);
+    this->drawPolygon(painter, poly);
     ++polyindex;
     poly = shape->getPolygon(polyindex);
   }
   // draw selected polygons in red
-  p_Painter->setPen(Qt::red);
+  painter.setPen(Qt::red);
   polyindex = 0;
   poly = p_Doc->getSelectedPolygon(polyindex);
   while (poly != NULL) {
-    this->drawPolygon(poly);
+    this->drawPolygon(painter, poly);
     ++polyindex;
     poly = p_Doc->getSelectedPolygon(polyindex);
   }
   // draw extra rectangle around current texcoord
-  p_Painter->drawRect((int)(p_texCurrent->u*255.0f)-2, (int)(p_texCurrent->v*255.0f)-2, 5, 5);
+  painter.drawRect((int)(p_texCurrent->u*255.0f)-2, (int)(p_texCurrent->v*255.0f)-2, 5, 5);
   EM_CERR("TextureView::paintEvent");
 }
 

--- a/src/textureview.h
+++ b/src/textureview.h
@@ -53,14 +53,13 @@ class TextureImageWidget : public QWidget {
 	void setCurrent(int i);
 	void setInit(QImage * image, TextureView * view);
  private:
-	void drawPolygon(Polygon3D * poly);
+    void drawPolygon(QPainter &painter, Polygon3D * poly);
 
 	TextureView * p_TextureView;
 	TexCoord * p_texCurrent;
 	int m_iCurrent;
 	PinEditDoc * p_Doc;
 	QImage * p_Image;
-	QPainter * p_Painter;
 };
 
 class TextureView: public QWidget, public Updateable, public Rebuildable  {

--- a/src/view2d.cpp
+++ b/src/view2d.cpp
@@ -56,7 +56,6 @@ View2D::View2D(int type, PinEditDoc * doc, QWidget * parent, const char * name, 
   m_iType = type;
   m_iX1 = m_iY1 = m_iX2 = m_iY2 = 0;
   p_Context = new CommandContext();
-  p_QPainter = new QPainter(this);
   this->setBackgroundMode(Qt::PaletteBase);
 }
 
@@ -142,7 +141,7 @@ void View2D::mouseMoveEvent(QMouseEvent* e) {
   //																								 QString().setNum(this->localy(m_iY2)));
 }
 
-void View2D::drawPolygon(Shape3D * shape, Polygon3D * poly, const Matrix & mtx) {
+void View2D::drawPolygon(QPainter &painter, Shape3D * shape, Polygon3D * poly, const Matrix & mtx) {
   //EM_CERR("View2D::drawPolygon");
   assert(shape != NULL);
   assert(poly != NULL);
@@ -165,13 +164,13 @@ void View2D::drawPolygon(Shape3D * shape, Polygon3D * poly, const Matrix & mtx) 
       EMath::applyMatrix(mtx, vtx1, vtxTrans1);
       EMath::applyMatrix(mtx, vtx2, vtxTrans2);
       switch (m_iType) {
-      case XY: p_QPainter->drawLine(this->screenx(vtxTrans1.x), this->screeny(-vtxTrans1.y), 
+      case XY: painter.drawLine(this->screenx(vtxTrans1.x), this->screeny(-vtxTrans1.y),
 				    this->screenx(vtxTrans2.x), this->screeny(-vtxTrans2.y)); 
 	break;
-      case XZ: p_QPainter->drawLine(this->screenx(vtxTrans1.x), this->screeny(vtxTrans1.z), 
+      case XZ: painter.drawLine(this->screenx(vtxTrans1.x), this->screeny(vtxTrans1.z),
 				    this->screenx(vtxTrans2.x), this->screeny(vtxTrans2.z)); 
 	break;
-      case ZY: p_QPainter->drawLine(this->screenx(vtxTrans1.z), this->screeny(-vtxTrans1.y), 
+      case ZY: painter.drawLine(this->screenx(vtxTrans1.z), this->screeny(-vtxTrans1.y),
 				    this->screenx(vtxTrans2.z), this->screeny(-vtxTrans2.y));
 	break;
       }
@@ -183,32 +182,32 @@ void View2D::drawPolygon(Shape3D * shape, Polygon3D * poly, const Matrix & mtx) 
     EMath::applyMatrix(mtx, vtx1, vtxTrans1);
     EMath::applyMatrix(mtx, vtx2, vtxTrans2);
     switch (m_iType) {
-    case XY: p_QPainter->drawLine(this->screenx(vtxTrans2.x), this->screeny(-vtxTrans2.y), 
+    case XY: painter.drawLine(this->screenx(vtxTrans2.x), this->screeny(-vtxTrans2.y),
 				  this->screenx(vtxTrans1.x), this->screeny(-vtxTrans1.y)); 
       break;
-    case XZ: p_QPainter->drawLine(this->screenx(vtxTrans2.x), this->screeny(vtxTrans2.z), 
+    case XZ: painter.drawLine(this->screenx(vtxTrans2.x), this->screeny(vtxTrans2.z),
 				  this->screenx(vtxTrans1.x), this->screeny(vtxTrans1.z)); 
       break;
-    case ZY: p_QPainter->drawLine(this->screenx(vtxTrans2.z), this->screeny(-vtxTrans2.y), 
+    case ZY: painter.drawLine(this->screenx(vtxTrans2.z), this->screeny(-vtxTrans2.y),
 				  this->screenx(vtxTrans1.z), this->screeny(-vtxTrans1.y)); 
       break;
     }
   }
 }
 
-void View2D::drawVertex(Shape3D * shape, const Vertex3D & vtx, const Matrix & mtx) {
+void View2D::drawVertex(QPainter &painter, Shape3D * shape, const Vertex3D & vtx, const Matrix & mtx) {
   //EM_CERR("View2D::drawPolygon");
   assert(shape != NULL);
   Vertex3D vtxA;
   EMath::applyMatrix(mtx, vtx, vtxA);
   switch (m_iType) {
-  case XY: p_QPainter->drawRect(this->screenx(vtxA.x)-1, this->screeny(-vtxA.y)-1, 3, 3); break;
-  case XZ: p_QPainter->drawRect(this->screenx(vtxA.x)-1, this->screeny(vtxA.z)-1,	3, 3); break;
-  case ZY: p_QPainter->drawRect(this->screenx(vtxA.z)-1, this->screeny(-vtxA.y)-1, 3, 3); break;
+  case XY: painter.drawRect(this->screenx(vtxA.x)-1, this->screeny(-vtxA.y)-1, 3, 3); break;
+  case XZ: painter.drawRect(this->screenx(vtxA.x)-1, this->screeny(vtxA.z)-1,	3, 3); break;
+  case ZY: painter.drawRect(this->screenx(vtxA.z)-1, this->screeny(-vtxA.y)-1, 3, 3); break;
   }
 }
 
-void View2D::drawShapeMode() {
+void View2D::drawShapeMode(QPainter &painter) {
   EM_CERR("View2D::drawShapeMode");
   // draw other shapes in group with lightgray
   if (p_Doc->getCurrentGroup() == NULL) return;
@@ -216,15 +215,15 @@ void View2D::drawShapeMode() {
   int sh = 0;
   Shape3D * shape = p_Doc->getCurrentGroup()->getShape3D(sh);
   while (shape != NULL) {
-    p_QPainter->setPen(Qt::lightGray);
+    painter.setPen(Qt::lightGray);
     int index = 0;
     Vertex3D * vtx = shape->getVertex3D(index);
     while (vtx != NULL) {
       //EM_CERR(vtx->x <<" "<< vtx->y <<" "<< vtx->z);
       switch (m_iType) {
-      case XY: p_QPainter->drawRect(this->screenx(vtx->x)-1, this->screeny(-vtx->y)-1, 3, 3); break;
-      case XZ: p_QPainter->drawRect(this->screenx(vtx->x)-1, this->screeny(vtx->z)-1, 3, 3); break;
-      case ZY: p_QPainter->drawRect(this->screenx(vtx->z)-1, this->screeny(-vtx->y)-1, 3, 3); break;
+      case XY: painter.drawRect(this->screenx(vtx->x)-1, this->screeny(-vtx->y)-1, 3, 3); break;
+      case XZ: painter.drawRect(this->screenx(vtx->x)-1, this->screeny(vtx->z)-1, 3, 3); break;
+      case ZY: painter.drawRect(this->screenx(vtx->z)-1, this->screeny(-vtx->y)-1, 3, 3); break;
       }
       index++;
       vtx = shape->getVertex3D(index);
@@ -232,7 +231,7 @@ void View2D::drawShapeMode() {
     index = 0;
     Polygon3D * poly = shape->getPolygon(index);
     while (poly != NULL) {
-      this->drawPolygon(shape, poly, EMath::identityMatrix);
+      this->drawPolygon(painter, shape, poly, EMath::identityMatrix);
       index++;
       poly = shape->getPolygon(index);
     }
@@ -245,15 +244,15 @@ void View2D::drawShapeMode() {
     return;
   }
   {	// normal vertices
-    p_QPainter->setPen(Qt::black);
+    painter.setPen(Qt::black);
     int index = 0;
     Vertex3D * vtx = shape->getVertex3D(index);
     while (vtx != NULL) {
       //EM_CERR(vtx->x <<" "<< vtx->y <<" "<< vtx->z);
       switch (m_iType) {
-      case XY: p_QPainter->drawRect(this->screenx(vtx->x)-1, this->screeny(-vtx->y)-1, 3, 3); break;
-      case XZ: p_QPainter->drawRect(this->screenx(vtx->x)-1, this->screeny(vtx->z)-1, 3, 3); break;
-      case ZY: p_QPainter->drawRect(this->screenx(vtx->z)-1, this->screeny(-vtx->y)-1, 3, 3); break;
+      case XY: painter.drawRect(this->screenx(vtx->x)-1, this->screeny(-vtx->y)-1, 3, 3); break;
+      case XZ: painter.drawRect(this->screenx(vtx->x)-1, this->screeny(vtx->z)-1, 3, 3); break;
+      case ZY: painter.drawRect(this->screenx(vtx->z)-1, this->screeny(-vtx->y)-1, 3, 3); break;
       }
       index++;
       vtx = shape->getVertex3D(index);
@@ -261,15 +260,15 @@ void View2D::drawShapeMode() {
   }	
 
   { // selected vertices
-    p_QPainter->setPen(Qt::red);
+    painter.setPen(Qt::red);
     int index = 0;
     Vertex3D * vtx = shape->getVertex3D(p_Doc->getSelectedVertex(index));
     while (vtx != NULL) {
       //EM_CERR(vtx->x <<" "<< vtx->y <<" "<< vtx->z);
       switch (m_iType) {
-      case XY: p_QPainter->drawRect(this->screenx(vtx->x)-1, this->screeny(-vtx->y)-1, 3, 3); break;
-      case XZ: p_QPainter->drawRect(this->screenx(vtx->x)-1, this->screeny(vtx->z)-1, 3, 3); break;
-      case ZY: p_QPainter->drawRect(this->screenx(vtx->z)-1, this->screeny(-vtx->y)-1, 3, 3); break;
+      case XY: painter.drawRect(this->screenx(vtx->x)-1, this->screeny(-vtx->y)-1, 3, 3); break;
+      case XZ: painter.drawRect(this->screenx(vtx->x)-1, this->screeny(vtx->z)-1, 3, 3); break;
+      case ZY: painter.drawRect(this->screenx(vtx->z)-1, this->screeny(-vtx->y)-1, 3, 3); break;
       }
       index++;
       vtx = shape->getVertex3D(p_Doc->getSelectedVertex(index));
@@ -277,30 +276,30 @@ void View2D::drawShapeMode() {
     vtx = shape->getVertex3D(p_Doc->getSelectedVertexExtra());
     if (vtx != NULL) {
       switch (m_iType) {
-      case XY: p_QPainter->drawRect(this->screenx(vtx->x)-2, this->screeny(-vtx->y)-1, 5, 5); break;
-      case XZ: p_QPainter->drawRect(this->screenx(vtx->x)-2, this->screeny(vtx->z)-1, 5, 5); break;
-      case ZY: p_QPainter->drawRect(this->screenx(vtx->z)-2, this->screeny(-vtx->y)-1, 5, 5); break;
+      case XY: painter.drawRect(this->screenx(vtx->x)-2, this->screeny(-vtx->y)-1, 5, 5); break;
+      case XZ: painter.drawRect(this->screenx(vtx->x)-2, this->screeny(vtx->z)-1, 5, 5); break;
+      case ZY: painter.drawRect(this->screenx(vtx->z)-2, this->screeny(-vtx->y)-1, 5, 5); break;
       }
     }
   }
 
   { // normal polygons
-    p_QPainter->setPen(Qt::black);
+    painter.setPen(Qt::black);
     int index = 0;
     Polygon3D * poly = shape->getPolygon(index);
     while (poly != NULL) {
-      this->drawPolygon(shape, poly, EMath::identityMatrix);
+      this->drawPolygon(painter, shape, poly, EMath::identityMatrix);
       index++;
       poly = shape->getPolygon(index);
     }
   }
 
   { // selected polygons
-    p_QPainter->setPen(Qt::red);
+    painter.setPen(Qt::red);
     int index = 0;
     Polygon3D * poly = p_Doc->getSelectedPolygon(index);
     while (poly != NULL) {
-      this->drawPolygon(shape, poly, EMath::identityMatrix);
+      this->drawPolygon(painter, shape, poly, EMath::identityMatrix);
       index++;
       poly = p_Doc->getSelectedPolygon(index);
     }
@@ -336,43 +335,43 @@ void View2D::drawShapeMode() {
     context.shape = p_Doc->getCurrentShape();
     context.group = p_Doc->getCurrentGroup();
     context.type = m_iType;
-    command->preview(context, this);
+    command->preview(context, this, painter);
   }
 }
 
-void View2D::drawGroupMode() {
+void View2D::drawGroupMode(QPainter &painter) {
   EM_CERR("View2D::drawGroupMode");
   Matrix mtx = EMath::identityMatrix;
   // draw all groups
-  this->drawGroup(p_Doc->getEngine(), mtx);
+  this->drawGroup(painter, p_Doc->getEngine(), mtx);
 }
 
 /* input: group to draw, matrix stack before applying this group */
-void View2D::drawGroup(Group * g, const Matrix & mtxP) {
+void View2D::drawGroup(QPainter &painter, Group * g, const Matrix & mtxP) {
   //EM_CERR("View3D::drawGroup");
   Matrix mtxT;
   EMath::matrixMulti(g->m_mtxSrc, mtxP, mtxT);
   // draw a cross to notate the centre of the group
   if (g == p_Doc->getCurrentGroup()) {
-    p_QPainter->setPen(Qt::red);
+    painter.setPen(Qt::red);
   } else {
-    p_QPainter->setPen(Qt::black);
+    painter.setPen(Qt::black);
   }
   switch (m_iType) {
   case XY: 
-    p_QPainter->drawLine(this->screenx(mtxT.t[0])-2, this->screeny(-mtxT.t[1]), 
+    painter.drawLine(this->screenx(mtxT.t[0])-2, this->screeny(-mtxT.t[1]),
 			 this->screenx(mtxT.t[0])+2, this->screeny(-mtxT.t[1]));
-    p_QPainter->drawLine(this->screenx(mtxT.t[0]), this->screeny(-mtxT.t[1])-2, 
+    painter.drawLine(this->screenx(mtxT.t[0]), this->screeny(-mtxT.t[1])-2,
 			 this->screenx(mtxT.t[0]), this->screeny(-mtxT.t[1])+2); break;
   case XZ: 
-    p_QPainter->drawLine(this->screenx(mtxT.t[0])-2, this->screeny(mtxT.t[2]),
+    painter.drawLine(this->screenx(mtxT.t[0])-2, this->screeny(mtxT.t[2]),
 			 this->screenx(mtxT.t[0])+2, this->screeny(mtxT.t[2]));
-    p_QPainter->drawLine(this->screenx(mtxT.t[0]), this->screeny(mtxT.t[2])-2,
+    painter.drawLine(this->screenx(mtxT.t[0]), this->screeny(mtxT.t[2])-2,
 			 this->screenx(mtxT.t[0]), this->screeny(mtxT.t[2])+2); break;
   case ZY: 
-    p_QPainter->drawLine(this->screenx(mtxT.t[2])-2, this->screeny(-mtxT.t[1]),
+    painter.drawLine(this->screenx(mtxT.t[2])-2, this->screeny(-mtxT.t[1]),
 			 this->screenx(mtxT.t[2])+2, this->screeny(-mtxT.t[1]));
-    p_QPainter->drawLine(this->screenx(mtxT.t[2]), this->screeny(-mtxT.t[1])-2,
+    painter.drawLine(this->screenx(mtxT.t[2]), this->screeny(-mtxT.t[1])-2,
 			 this->screenx(mtxT.t[2]), this->screeny(-mtxT.t[1])+2); break;
   }
 
@@ -383,7 +382,7 @@ void View2D::drawGroup(Group * g, const Matrix & mtxP) {
     int polyindex = 0;
     Polygon3D * poly = shape->getPolygon(polyindex);
     while (poly != NULL) {
-      this->drawPolygon(shape, poly, mtxT);
+      this->drawPolygon(painter, shape, poly, mtxT);
       polyindex++;
       poly = shape->getPolygon(polyindex);
     }
@@ -421,23 +420,23 @@ void View2D::drawGroup(Group * g, const Matrix & mtxP) {
     context.shape = p_Doc->getCurrentShape();
     context.group = p_Doc->getCurrentGroup();
     context.type = m_iType;
-    command->preview(context, this);
+    command->preview(context, this, painter);
   }
   // TODO recurse the temporary movement to child groups
   int index = 0;
   Group * group = g->getGroup(index);
   while (group != NULL) {
-    this->drawGroup(group, mtxT);
+    this->drawGroup(painter, group, mtxT);
     index++;
     group = g->getGroup(index);
   }
 }
 
-void View2D::drawGrid() {
+void View2D::drawGrid(QPainter& painter) {
   //EM_CERR("View2D::drawGrid");
   QString str = QString().setNum(this->localx(m_iX2)) + " " + 
     QString().setNum(this->localy(m_iY2));
-  p_QPainter->setPen(Qt::lightGray);
+  painter.setPen(Qt::lightGray);
   float step = m_fZoom;
   int w = this->size().width();
   int h = this->size().height();
@@ -446,22 +445,22 @@ void View2D::drawGrid() {
   float xoffset = (m_iXOffset - w_2)%(int)m_fZoom;
   float yoffset = (m_iYOffset - h_2)%(int)m_fZoom;
   for (float x=w_2; x<w; x += step) {
-    p_QPainter->drawLine((int)(x+xoffset), 0, (int)(x+xoffset), h);
+    painter.drawLine((int)(x+xoffset), 0, (int)(x+xoffset), h);
    }
   for (float x=w_2-step; x>0; x-=step) {
-     p_QPainter->drawLine((int)(x+xoffset), 0, (int)(x+xoffset), h);
+     painter.drawLine((int)(x+xoffset), 0, (int)(x+xoffset), h);
   }
   for (float y=h_2; y<h; y+=step) {
-     p_QPainter->drawLine(0, (int)(y+yoffset), w, (int)(y+yoffset));
+     painter.drawLine(0, (int)(y+yoffset), w, (int)(y+yoffset));
   }
   for (float y=h_2-step; y>0; y-=step) {
-    p_QPainter->drawLine(0, (int)(y+yoffset), w, (int)(y+yoffset));
+    painter.drawLine(0, (int)(y+yoffset), w, (int)(y+yoffset));
   }
   
-  p_QPainter->setPen(Qt::darkGray);
-  p_QPainter->drawLine(this->screenx(-100), this->screeny(0), 
+  painter.setPen(Qt::darkGray);
+  painter.drawLine(this->screenx(-100), this->screeny(0),
 		       this->screenx(100), this->screeny(0));
-  p_QPainter->drawLine(this->screenx(0), this->screeny(-100), 
+  painter.drawLine(this->screenx(0), this->screeny(-100),
  		       this->screenx(0), this->screeny(100));
   // drawing text triggers strange no-more resize qt bug!
   //p_QPainter->setPen(Qt::black);
@@ -471,13 +470,15 @@ void View2D::drawGrid() {
 // this is the function who draws stuff to the screen
 void View2D::paintEvent(QPaintEvent *) {
   //EM_CERR("view2d::paintevent");
+
+    QPainter painter(this);
   if (m_bGrid) {
-    this->drawGrid();
+    this->drawGrid(painter);
   }
   if (m_iMode == EM_SHAPE_MODE) {
-    this->drawShapeMode();
+    this->drawShapeMode(painter);
   } else if (m_iMode == EM_GROUP_MODE) {
-    this->drawGroupMode();
+    this->drawGroupMode(painter);
   }
 }
 

--- a/src/view2d.h
+++ b/src/view2d.h
@@ -50,22 +50,20 @@ class View2D : public QWidget, public Updateable {
 	void showGrid(bool grid) { m_bGrid = grid; };
 	void paintEvent(QPaintEvent * e);
 	void doUpdate();
-	QPainter * getPainter() { return p_QPainter; }; 
 	inline int screenx(float x) { return (int)(x*m_fZoom + m_iXOffset); };
 	inline int screeny(float y) { return (int)(y*m_fZoom + m_iYOffset); };
 	inline float localx(int x) { return (float)(x - m_iXOffset) / m_fZoom; };
 	inline float localy(int y) { return (float)(y - m_iYOffset) / m_fZoom; };
-	void drawGroup(Group * g, const Matrix & mtx);
-	void drawPolygon(Shape3D * shape, Polygon3D * poly, const Matrix & mtx);
-	void drawVertex(Shape3D * shape, const Vertex3D & vtx, const Matrix & mtx);
+    void drawGroup(QPainter &painter, Group * g, const Matrix & mtx);
+    void drawPolygon(QPainter &painter, Shape3D * shape, Polygon3D * poly, const Matrix & mtx);
+    void drawVertex(QPainter &painter, Shape3D * shape, const Vertex3D & vtx, const Matrix & mtx);
  protected:
-	void drawShapeMode();
-	void drawGroupMode();
-	void drawGrid();
+    void drawShapeMode(QPainter &painter);
+    void drawGroupMode(QPainter &painter);
+    void drawGrid(QPainter &painter);
 	int m_iMode;
 	bool m_bGrid;
 	CommandContext * p_Context;
-	QPainter * p_QPainter;
 	PinEditDoc * p_Doc;
 	float m_fZoom;
 	int m_iXOffset;


### PR DESCRIPTION
Hello,

I've succeeded to build pinedit with Qt4 inside Qt Creator, but the QPainter behavior has changed between Qt3 and Qt4. With Qt4 the QPainter object has to be created only during `paintEvent`, as explained in [Qt4 documentation](https://doc.qt.io/qt-4.8/qpainter.html#details).

That's why most of the graphic interactions were not working, like the grid, the selection and the action previews. The fix is to add extra argument QPainter for every drawing methods that are called from the View2D::paintEvent method.

This pull request also includes few compilation warning fixes. 