### PR TITLE
Fix debian package generation with Qt4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ INSTALL
 compile
 ltmain.sh
 mkinstalldirs
+autoreconf.after
+autoreconf.before
+debhelper-build-stamp
 
 libltdl/
 

--- a/bootstrap
+++ b/bootstrap
@@ -6,8 +6,8 @@ set -e
 make -k distclean clean || echo "ignore: "
 rm -rf libltdl configure ltmain.sh
 
-#libtoolize --ltdl --force --copy
-libtoolize --ltdl --force
+libtoolize --ltdl --force --copy
+#libtoolize --ltdl --force
 
 autoheader
 automake --add-missing

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,9 @@ Section: games
 Priority: extra
 Maintainer: Philippe Coval <rzr@gna.org>
 Build-Depends: debhelper (>= 7.0.50~), autotools-dev,
- libtool, libltdl-dev, pinball-dev, libgl-dev, libsdl1.2-dev, libsdl-image1.2-dev, libsdl-mixer1.2-dev,
+ libtool, libltdl-dev,
+ pinball-dev,
+ libgl-dev, libsdl1.2-dev, libsdl-image1.2-dev, libsdl-mixer1.2-dev,
  libqt4-dev, libqt4-opengl-dev
 Standards-Version: 3.9.1
 Homepage: http://pinball.sf.net

--- a/debian/control
+++ b/debian/control
@@ -3,15 +3,8 @@ Section: games
 Priority: extra
 Maintainer: Philippe Coval <rzr@gna.org>
 Build-Depends: debhelper (>= 7.0.50~), autotools-dev,
- libtool, libltdl-dev,
- libqt3-mt-dev, libqt3-compat-headers,
- pinball-dev,
- autoconf, automake, libtool, sp, sgmlspl, docbook, docbook-utils,
- libltdl-dev (>= 2.2.6b),
- libgl1-mesa-dev | xlibmesa-gl-dev | mesag-dev | libgl-dev, freeglut3-dev,
- libsdl1.2-dev,  libsdl-image1.2-dev, libpng-dev, libtiff4-dev, libaa1-dev,
- libsdl-mixer1.2-dev, libogg-dev, libvorbis-dev, 
- libasound2-dev [!kfreebsd-i386 !kfreebsd-amd64 !hurd-i386]
+ libtool, libltdl-dev, pinball-dev, libgl-dev, libsdl1.2-dev, libsdl-image1.2-dev, libsdl-mixer1.2-dev,
+ libqt4-dev, libqt4-opengl-dev
 Standards-Version: 3.9.1
 Homepage: http://pinball.sf.net
 #Vcs-Git: git://git.debian.org/collab-maint/pinedit.git

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,7 @@ export DH_VERBOSE=1
 	dh $@ 
 
 override_dh_auto_configure:
+	dh_autoreconf 
 	./bootstrap
 	PINBALL_CONFIG="/usr/games/pinball-config" \
 	dh_auto_configure -- \


### PR DESCRIPTION
This pull request tries to fix Debian package generation since Qt4 upgrade.

- Replace libqt3 by libqt4
- Force autoreconf in debian rules
- Removing unneeded dependencies

I've removed sgmlspl, docbook and docbook-utils because no documentation is generated at the moment.

About OpenGL library `libgl1-mesa-dev | xlibmesa-gl-dev | mesag-dev | libgl-dev`, only the last one is required for Debian (`libgl-dev`).

However there is still serious errors and warnings in the Lintian output, but I don't know if this is new:
```
E: pinedit changes: bad-distribution-in-changes-file hardy
E: pinedit: embedded-library usr/games/pinedit: ltdl
W: pinedit: wrong-bug-number-in-closes l21:#nnnn
W: pinedit: duplicate-changelog-files usr/share/doc/pinedit/NEWS.gz usr/share/doc/pinedit/changelog.gz
W: pinedit: binary-without-manpage usr/games/pinball-template
W: pinedit: binary-without-manpage usr/games/pinedit
W: pinedit: menu-command-not-in-package usr/share/menu/pinedit:2 usr/bin/pinedit
W: pinedit: doc-base-unknown-section pinedit:5 games
W: pinedit: script-not-executable usr/share/games/pinedit/template/libtool
```

Tested with Debian Stretch and Debian Sid.

Should close #1