### PR TITLE
Update my email

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,22 +2,22 @@ pinedit (0.0.20110501-0ubuntu0~rzr2) hardy; urgency=low
 
   * WIP: http://rzr.online.fr/q/snapshot#pinedit
 
- -- Philippe Coval <rzr@gna.org>  Sun, 01 May 2011 15:23:30 +0200
+ -- Philippe Coval <rzr@users.sf.net>  Sun, 01 May 2011 15:23:30 +0200
 
 pinedit (0.0.20110501-0ubuntu0~rzr0+oneiric0) oneiric; urgency=low
 
   * WIP: http://rzr.online.fr/q/snapshot#pinedit
 
- -- Philippe Coval <rzr@gna.org>  Sun, 01 May 2011 10:18:48 +0200
+ -- Philippe Coval <rzr@users.sf.net>  Sun, 01 May 2011 10:18:48 +0200
 
 pinedit (0.0.0-0) unstable; urgency=low
 
   * http://rzr.online.fr/q/snapshot
 
- -- Philippe Coval <rzr@gna.org>  Fri, 15 Apr 2011 12:32:46 +0200
+ -- Philippe Coval <rzr@users.sf.net>  Fri, 15 Apr 2011 12:32:46 +0200
 
 pinedit (0.3.1-0) unstable; urgency=low
 
   * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
 
- -- Philippe Coval <rzr@gna.org>  Fri, 15 Apr 2011 11:57:42 +0200
+ -- Philippe Coval <rzr@users.sf.net>  Fri, 15 Apr 2011 11:57:42 +0200

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: pinedit
 Section: games
 Priority: extra
-Maintainer: Philippe Coval <rzr@gna.org>
+Maintainer: Philippe Coval <rzr@users.sf.net>
 Build-Depends: debhelper (>= 7.0.50~), autotools-dev,
  cmake,
  pinball-dev,

--- a/debian/copyright
+++ b/debian/copyright
@@ -22,7 +22,7 @@ License: GPL-2+
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
 
 Files: debian/*
-Copyright: 2011 Philippe Coval <rzr@gna.org>
+Copyright: 2011 Philippe Coval <rzr@users.sf.net>
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/pinedit.sgml
+++ b/debian/pinedit.sgml
@@ -24,7 +24,7 @@ manpage.1: manpage.sgml
   <!-- SECTION should be 1-8, maybe w/ subsection other parameters are
        allowed: see man(7), man(1). -->
   <!ENTITY dhsection   "<manvolnum>6</manvolnum>">
-  <!ENTITY dhemail     "<email>rzr@gna.org</email>">
+  <!ENTITY dhemail     "<email>rzr@users.sf.net</email>">
   <!ENTITY dhusername  "Philippe Coval">
   <!ENTITY dhucpackage "<refentrytitle>PINEDIT</refentrytitle>">
   <!ENTITY dhpackage   "pinedit">


### PR DESCRIPTION
gna.org is now defunct

I can easly prove my id if you trust Debian:

https://qa.debian.org/developer.php?login=rzr@users.sf.net
https://qa.debian.org/developer.php?login=rzr@gna.org
Signed-off-by: Philippe Coval <rzr@users.sf.net>